### PR TITLE
Protect against DNS rebind attacks

### DIFF
--- a/lib/Hopscotch.pm
+++ b/lib/Hopscotch.pm
@@ -178,11 +178,11 @@ if (PARANOID) {
     $furl->{inet_aton} = sub {
         my ($host) = @_;
         my ($addrs) = try { $dns->resolve($host) };
-        unless (defined $addrs) {
+        unless (ref $addrs eq 'ARRAY') {
             $! = 14; # EFAULT = Bad address ;)
             return;
         }
-        Socket::inet_aton($host);
+        Socket::inet_aton($addrs->[0]);
     }
 }
 


### PR DESCRIPTION
We resolve the incoming hostname. If it passes, we let Furl run, which
resolves it again. An attacker that controls the DNS could use a TTL of
0 and return a whitelisted IP first, then a blacklisted IP on the second
query, defeating the protection.

The solution is to only do one DNS query, and pass the results down to
Furl.